### PR TITLE
[IMPROVES] [BREAKING-CHANGES] Improve EncryptManager saltIV encoding.

### DIFF
--- a/App/Manager/Env/EnvManager.php
+++ b/App/Manager/Env/EnvManager.php
@@ -225,7 +225,7 @@ class EnvManager
 
         $this->addValue('SALT', $salt);
         $this->addValue('SALT_PASS', $saltPass);
-        $this->addValue('SALT_IV', openssl_random_pseudo_bytes(16));
+        $this->addValue('SALT_IV', bin2hex(openssl_random_pseudo_bytes(16)));
     }
 
     private function oneShotCmwVersionFile(): void

--- a/App/Manager/Security/EncryptManager.php
+++ b/App/Manager/Security/EncryptManager.php
@@ -21,7 +21,7 @@ class EncryptManager
 
     public static function getSaltIv(): string
     {
-        return EnvManager::getInstance()->getValue('SALT_IV');
+        return hex2bin(EnvManager::getInstance()->getValue('SALT_IV'));
     }
 
     /**


### PR DESCRIPTION
With this commit, you will not able to login or use encrypted data.

If you want to manually update your .env SALT_IV, do this:

```php

<?= bin2hex(EncryptManager::getSaltIv()) ?>

````

Copy the value et past this to your .env SALT_IV.