### PR TITLE
[IMPROVE] Add ComponentsManager

### DIFF
--- a/App/Manager/Components/Base/ButtonComponentBase.php
+++ b/App/Manager/Components/Base/ButtonComponentBase.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace CMW\Manager\Components\Base;
+
+use CMW\Manager\Components\IComponent;
+use JetBrains\PhpStorm\ExpectedValues;
+
+class ButtonComponentBase extends IComponent
+{
+    private string $text = "Button";
+    #[ExpectedValues(['button', 'submit', 'reset'])] private string $type = "submit";
+    private bool $isDisabled = false;
+    private string $onClick = "";
+
+    /**
+     * @param string $text
+     * @return $this
+     */
+    public function setText(string $text): ButtonComponentBase
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @return $this
+     */
+    public function setType(#[ExpectedValues(['button', 'submit', 'reset'])] string $type): ButtonComponentBase
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * @param bool $isDisabled
+     * @return $this
+     */
+    public function setIsDisabled(bool $isDisabled): ButtonComponentBase
+    {
+        $this->isDisabled = $isDisabled;
+        return $this;
+    }
+
+    /**
+     * @param string $onClick
+     * @return $this
+     */
+    public function setOnClick(string $onClick): ButtonComponentBase
+    {
+        $this->onClick = $onClick;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    private function showDisabled(): string
+    {
+        return $this->isDisabled ? 'disabled' : '';
+    }
+
+    public function render(): void
+    {
+        print "<button {$this->showId()} type='$this->type' class='$this->classes' {$this->showDisabled()} 
+                        onclick='$this->onClick'>
+                    $this->text
+                </button>";
+    }
+}

--- a/App/Manager/Components/Base/DivComponentBase.php
+++ b/App/Manager/Components/Base/DivComponentBase.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CMW\Manager\Components\Base;
+
+use CMW\Manager\Components\IComponent;
+
+class DivComponentBase extends IComponent
+{
+    private string $onClick = "";
+    /* @var IComponent[] $children */
+    private array $children;
+
+    /**
+     * @param string $onClick
+     * @return DivComponentBase
+     */
+    public function setOnClick(string $onClick): DivComponentBase
+    {
+        $this->onClick = $onClick;
+        return $this;
+    }
+
+    /**
+     * @param array $children
+     * @return DivComponentBase
+     */
+    public function setChildren(array $children): DivComponentBase
+    {
+        $this->children = $children;
+        return $this;
+    }
+
+    /**
+     * @return void
+     */
+    public function printChildren(): void
+    {
+        foreach ($this->children as $child) {
+            $child->render();
+        }
+    }
+
+    public function render(): void
+    {
+        print "<div {$this->showId()} class='$this->classes' onclick='$this->onClick'>";
+        $this->printChildren();
+        print "</div>";
+    }
+}

--- a/App/Manager/Components/Base/FormComponentBase.php
+++ b/App/Manager/Components/Base/FormComponentBase.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace CMW\Manager\Components\Base;
+
+use CMW\Manager\Components\IComponent;
+use CMW\Manager\Security\SecurityManager;
+use JetBrains\PhpStorm\ExpectedValues;
+
+class FormComponentBase extends IComponent
+{
+
+    private string $method = "POST";
+    private string $action = "";
+    private string $enctype = "application/x-www-form-urlencoded";
+    private string $name = "";
+    private string $onSubmit = "";
+    /* @var IComponent[] $children */
+    private array $children = [];
+
+    /**
+     * @param string $method
+     * @return FormComponentBase
+     */
+    public function setMethod(#[ExpectedValues(['post', 'get', 'dialog'])] string $method): FormComponentBase
+    {
+        $this->method = $method;
+        return $this;
+    }
+
+    /**
+     * @param string $action
+     * @return FormComponentBase
+     */
+    public function setAction(string $action): FormComponentBase
+    {
+        $this->action = $action;
+        return $this;
+    }
+
+    /**
+     * @param string $enctype
+     * @return FormComponentBase
+     */
+    public function setEnctype(
+        #[ExpectedValues(['multipart/form-data', 'application/x-www-form-urlencoded', 'text/plain'])]
+        string $enctype,
+    ): FormComponentBase
+    {
+        $this->enctype = $enctype;
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return FormComponentBase
+     */
+    public function setName(string $name): FormComponentBase
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @param string $onSubmit
+     * @return FormComponentBase
+     */
+    public function setOnSubmit(string $onSubmit): FormComponentBase
+    {
+        $this->onSubmit = $onSubmit;
+        return $this;
+    }
+
+    /**
+     * @param IComponent[] $children
+     * @return FormComponentBase
+     */
+    public function setChildren(array $children): FormComponentBase
+    {
+        $this->children = $children;
+        return $this;
+    }
+
+    /**
+     * @return void
+     */
+    public function printChildren(): void
+    {
+        foreach ($this->children as $child) {
+            $child->render();
+        }
+    }
+
+    public function render(): void
+    {
+        print "<form {$this->showId()}
+                    method='$this->method' 
+                    action='$this->action' 
+                    enctype='$this->enctype' 
+                    name='$this->name'
+                    class='$this->classes'
+                    onsubmit='$this->onSubmit'>";
+        (new SecurityManager())->insertHiddenToken();
+        $this->printChildren();
+        print "</form>";
+    }
+}

--- a/App/Manager/Components/Base/HeaderComponentBase.php
+++ b/App/Manager/Components/Base/HeaderComponentBase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CMW\Manager\Components\Base;
+
+use CMW\Manager\Components\IComponent;
+
+class HeaderComponentBase extends IComponent
+{
+    /* @var IComponent[] $children */
+    private array $children;
+
+    /**
+     * @param array $children
+     * @return HeaderComponentBase
+     */
+    public function setChildren(array $children): HeaderComponentBase
+    {
+        $this->children = $children;
+        return $this;
+    }
+
+    /**
+     * @return void
+     */
+    public function printChildren(): void
+    {
+        foreach ($this->children as $child) {
+            $child->render();
+        }
+    }
+
+    public function render(): void
+    {
+        print "<header {$this->showId()} class='$this->classes'>";
+        $this->printChildren();
+        print "</header>";
+    }
+}

--- a/App/Manager/Components/Base/HeadingComponentBase.php
+++ b/App/Manager/Components/Base/HeadingComponentBase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CMW\Manager\Components\Base;
+
+use CMW\Manager\Components\IComponent;
+use JetBrains\PhpStorm\ExpectedValues;
+
+class HeadingComponentBase extends IComponent
+{
+
+    private int $level = 1;
+    private string $text = "";
+
+    /**
+     * @param int $level
+     * @return HeadingComponentBase
+     */
+    public function setLevel(#[ExpectedValues([1, 2, 3, 4, 5, 6])] int $level): HeadingComponentBase
+    {
+        $this->level = $level;
+        return $this;
+    }
+
+    /**
+     * @param string $text
+     * @return HeadingComponentBase
+     */
+    public function setText(string $text): HeadingComponentBase
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    public function render(): void
+    {
+        print "<h$this->level {$this->showId()} class='$this->classes'>$this->text</h$this->level>";
+    }
+}

--- a/App/Manager/Components/Base/HrComponentBase.php
+++ b/App/Manager/Components/Base/HrComponentBase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CMW\Manager\Components\Base;
+
+use CMW\Manager\Components\IComponent;
+
+class HrComponentBase extends IComponent
+{
+    public function render(): void
+    {
+       print "<hr {$this->showId()} class='$this->classes'>";
+    }
+}

--- a/App/Manager/Components/Base/InputComponentBase.php
+++ b/App/Manager/Components/Base/InputComponentBase.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace CMW\Manager\Components\Base;
+
+use CMW\Manager\Components\IComponent;
+use JetBrains\PhpStorm\ExpectedValues;
+
+class InputComponentBase extends IComponent
+{
+    private string $placeholder = "Enter text";
+    private string $type = "text";
+    private string $name = "undefined";
+    private bool $isRequired = true;
+    private bool $isReadOnly = false;
+    private bool $isDisabled = false;
+
+    /**
+     * @param string $placeholder
+     * @return InputComponentBase
+     */
+    public function setPlaceholder(string $placeholder): InputComponentBase
+    {
+        $this->placeholder = $placeholder;
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @return InputComponentBase
+     */
+    public function setType(#[ExpectedValues(['button', 'checkbox', 'color', 'date', 'datetime-local', 'email', 'file', 'hidden', 'image',
+        'month', 'number', 'password', 'radio', 'range', 'reset', 'search', 'submit', 'tel', 'text', 'time', 'url',
+        'week'])] string $type): InputComponentBase
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return InputComponentBase
+     */
+    public function setName(string $name): InputComponentBase
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @param bool $isRequired
+     * @return InputComponentBase
+     */
+    public function setIsRequired(bool $isRequired): InputComponentBase
+    {
+        $this->isRequired = $isRequired;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    private function showRequired(): string
+    {
+        return $this->isRequired ? 'required' : '';
+    }
+
+    /**
+     * @param bool $isReadOnly
+     * @return InputComponentBase
+     */
+    public function setIsReadOnly(bool $isReadOnly): InputComponentBase
+    {
+        $this->isReadOnly = $isReadOnly;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    private function showReadOnly(): string
+    {
+        return $this->isReadOnly ? 'readonly' : '';
+    }
+
+    /**
+     * @param bool $isDisabled
+     * @return InputComponentBase
+     */
+    public function setIsDisabled(bool $isDisabled): InputComponentBase
+    {
+        $this->isDisabled = $isDisabled;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    private function showDisabled(): string
+    {
+        return $this->isDisabled ? 'disabled' : '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(): void
+    {
+        print "<input   {$this->showId()}
+                        type='$this->type' 
+                        class='$this->classes'
+                        name='$this->name'
+                        placeholder='$this->placeholder'
+                        {$this->showRequired()}
+                        {$this->showReadOnly()}
+                        {$this->showDisabled()}>";
+    }
+}

--- a/App/Manager/Components/ComponentsManager.php
+++ b/App/Manager/Components/ComponentsManager.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CMW\Manager\Components;
+
+use CMW\Manager\Env\EnvManager;
+use CMW\Manager\Manager\AbstractManager;
+use CMW\Utils\Directory;
+use function is_dir;
+
+class ComponentsManager extends AbstractManager
+{
+
+    /**
+     * @param string $themeName
+     * @return void
+     * @desc Load theme components
+     */
+    public function loadThemeComponents(string $themeName): void
+    {
+        $path = EnvManager::getInstance()->getValue('DIR') . 'Public/Themes/' . $themeName . '/Components';
+
+        //If dir Elements doesn't exist, ignore.
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $files = Directory::getFilesRecursively($path);
+
+        foreach ($files as $file) {
+            require_once $file;
+        }
+    }
+
+}

--- a/App/Manager/Components/IComponent.php
+++ b/App/Manager/Components/IComponent.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace CMW\Manager\Components;
+
+use CMW\Manager\Components\Base\ButtonComponentBase;
+use CMW\Manager\Components\Base\InputComponentBase;
+
+abstract class IComponent
+{
+
+    protected ?string $id = null;
+    protected string $classes = "";
+
+    /**
+     * @param string|null $id
+     * @return InputComponentBase
+     */
+    public function setId(?string $id): static
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    protected function showId(): string
+    {
+        return $this->id ? "id='$this->id'" : '';
+    }
+
+    /**
+     * @param string $classes
+     * @return $this
+     */
+    public function setClasses(string $classes): static
+    {
+        $this->classes = $classes;
+        return $this;
+    }
+
+    /**
+     * @return static
+     * @desc Create a new instance of the component.
+     */
+    public static function create(): static
+    {
+        return new static();
+    }
+
+    /**
+     * @return void
+     * @desc Render the component.
+     */
+    abstract public function render(): void;
+}

--- a/App/Manager/Views/View.php
+++ b/App/Manager/Views/View.php
@@ -6,6 +6,7 @@ use CMW\Controller\Core\CoreController;
 use CMW\Controller\Core\MenusController;
 use CMW\Controller\Core\ThemeController;
 use CMW\Controller\Users\UsersController;
+use CMW\Manager\Components\ComponentsManager;
 use CMW\Manager\Env\EnvManager;
 use CMW\Manager\Flash\Flash;
 use CMW\Manager\Router\RouterException;
@@ -24,6 +25,7 @@ class View
     private array $variables;
     private bool $needAdminControl;
     private bool $isAdminFile;
+    private string $themeName;
 
     /**
      * @param string|null $package
@@ -38,6 +40,7 @@ class View
         $this->variables = [];
         $this->needAdminControl = false;
         $this->isAdminFile = $isAdminFile;
+        $this->themeName = ThemeManager::getInstance()->getCurrentTheme()->name();
     }
 
     /**
@@ -260,10 +263,10 @@ class View
         if ($this->customPath !== null) {
             return $this->customPath;
         }
-        $theme = ThemeManager::getInstance()->getCurrentTheme()->name();
+
         return ($this->isAdminFile)
             ? "App/Package/$this->package/Views/$this->viewFile.admin.view.php"
-            : "Public/Themes/$theme/Views/$this->package/$this->viewFile.view.php";
+            : "Public/Themes/$this->themeName/Views/$this->package/$this->viewFile.view.php";
     }
 
     /**
@@ -274,10 +277,10 @@ class View
         if ($this->customTemplate !== null) {
             return $this->customTemplate;
         }
-        $theme = ThemeManager::getInstance()->getCurrentTheme()->name();
+
         return ($this->isAdminFile)
             ? EnvManager::getInstance()->getValue('PATH_ADMIN_VIEW') . 'template.php'
-            : "Public/Themes/$theme/Views/template.php";
+            : "Public/Themes/$this->themeName/Views/template.php";
     }
 
     /**
@@ -364,7 +367,8 @@ class View
             throw new RouterException(null, 404);  // TODO Real errors?
         }
 
-        // Show Alerts
+        //Load Elements
+        ComponentsManager::getInstance()->loadThemeComponents($this->themeName);
 
         ob_start();
         require_once ($path);

--- a/Public/Themes/Sampler/Components/Containers/HeaderContainerComponent.php
+++ b/Public/Themes/Sampler/Components/Containers/HeaderContainerComponent.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CMW\Theme\Sampler\Elements\Containers;
+
+use CMW\Manager\Components\Base\DivComponentBase;
+use CMW\Manager\Components\Base\HeaderComponentBase;
+
+class HeaderContainerComponent extends HeaderComponentBase
+{
+    public function render(): void
+    {
+        HeaderComponentBase::create()
+            ->setClasses("masthead")
+            ->setChildren([
+                DivComponentBase::create()->setClasses('container px-4 px-lg-5 h-100')
+                    ->setChildren([
+
+                ])
+            ])
+            ->render();
+    }
+
+}

--- a/Public/Themes/Sampler/Components/Containers/HeroWrapperComponent.php
+++ b/Public/Themes/Sampler/Components/Containers/HeroWrapperComponent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace CMW\Theme\Sampler\Elements\Containers;
+
+use CMW\Manager\Components\Base\DivComponentBase;
+
+class HeroWrapperComponent extends DivComponentBase
+{
+    public function render(): void
+    {
+        DivComponentBase::create()
+            ->setClasses('row gx-4 gx-lg-5 h-100 align-items-center justify-content-center text-center')
+            ->setChildren([
+                TitleContainer::create(),
+            ])
+            ->render();
+    }
+}

--- a/Public/Themes/Sampler/Components/Containers/TitleContainer.php
+++ b/Public/Themes/Sampler/Components/Containers/TitleContainer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CMW\Theme\Sampler\Elements\Containers;
+
+use CMW\Manager\Components\Base\DivComponentBase;
+use CMW\Theme\Sampler\Elements\Heading\TitleComponent;
+use CMW\Theme\Sampler\Elements\Hr\SeparatorComponent;
+
+class TitleContainer extends DivComponentBase
+{
+    public function render(): void
+    {
+        DivComponentBase::create()
+            ->setClasses('col-lg-8 align-self-end')
+            ->setChildren([
+                TitleComponent::create(),
+                SeparatorComponent::create(),
+            ])
+            ->render();
+    }
+
+}

--- a/Public/Themes/Sampler/Components/Heading/TitleComponent.php
+++ b/Public/Themes/Sampler/Components/Heading/TitleComponent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CMW\Theme\Sampler\Elements\Heading;
+
+
+use CMW\Manager\Components\Base\HeadingComponentBase;
+
+class TitleComponent extends HeadingComponentBase
+{
+    private string $text = "CraftMyWebsite";
+
+    public function setText(string $text): static
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    public function render(): void
+    {
+        HeadingComponentBase::create()
+            ->setLevel(1)
+            ->setClasses("text-white font-weight-bold")
+            ->setText($this->text)
+            ->render();
+    }
+}

--- a/Public/Themes/Sampler/Components/Hr/SeparatorComponent.php
+++ b/Public/Themes/Sampler/Components/Hr/SeparatorComponent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CMW\Theme\Sampler\Elements\Hr;
+
+use CMW\Manager\Components\Base\HrComponentBase;
+
+class SeparatorComponent extends HrComponentBase
+{
+    public function render(): void
+    {
+        HrComponentBase::create()
+            ->setClasses("divider")
+            ->render();
+    }
+}

--- a/Public/Themes/Sampler/Resources/Assets/Css/main.css
+++ b/Public/Themes/Sampler/Resources/Assets/Css/main.css
@@ -11415,6 +11415,7 @@ header.masthead {
   background-repeat: no-repeat;
   background-attachment: scroll;
   background-size: cover;
+  background: var(--header-background);
 }
 header.masthead h1, header.masthead .h1 {
   font-size: 2.25rem;

--- a/Public/Themes/Sampler/Views/Core/home.view.php
+++ b/Public/Themes/Sampler/Views/Core/home.view.php
@@ -1,7 +1,9 @@
 <?php
+
 use CMW\Controller\Users\UsersController;
 use CMW\Manager\Env\EnvManager;
 use CMW\Model\Core\ThemeModel;
+use CMW\Theme\Sampler\Elements\Containers\TitleContainer;
 use CMW\Utils\Website;
 
 Website::setTitle('Accueil');
@@ -15,10 +17,9 @@ Website::setDescription("page d'accueil de CraftMyWebsite");
             url('<?= ThemeModel::getInstance()->fetchImageLink('background') ?>');">
     <div class="container px-4 px-lg-5 h-100">
         <div class="row gx-4 gx-lg-5 h-100 align-items-center justify-content-center text-center">
-            <div class="col-lg-8 align-self-end">
-                <h1 class="text-white font-weight-bold">CraftMyWebsite</h1>
-                <hr class="divider"/>
-            </div>
+
+            <?php TitleContainer::create()->render(); ?>
+
             <div class="col-lg-8 align-self-baseline">
                 <p class="text-white-75">Bienvenue sur votre site !</p>
                 <p class="text-white-75 mb-5">Il est maintenant temps de commencer la configuration, connectez-vous pour
@@ -28,7 +29,8 @@ Website::setDescription("page d'accueil de CraftMyWebsite");
                        href="<?= EnvManager::getInstance()->getValue('PATH_SUBFOLDER') ?>cmw-admin">Panel
                         d'administration</a>
                 <?php else: ?>
-                    <a class="btn btn-xl" style="background: <?= ThemeModel::getInstance()->fetchConfigValue('buttonColor') ?>"
+                    <a class="btn btn-xl"
+                       style="background: <?= ThemeModel::getInstance()->fetchConfigValue('buttonColor') ?>"
                        href="<?= EnvManager::getInstance()->getValue('PATH_SUBFOLDER') ?>login">Connexion</a>
                 <?php endif; ?>
             </div>

--- a/Public/Themes/Sampler/Views/Includes/head.inc.php
+++ b/Public/Themes/Sampler/Views/Includes/head.inc.php
@@ -6,6 +6,7 @@ use CMW\Controller\Core\CoreController;
 use CMW\Manager\Env\EnvManager;
 use CMW\Manager\Uploads\ImagesManager;
 use CMW\Manager\Views\View;
+use CMW\Model\Core\ThemeModel;
 use CMW\Utils\Website;
 
 /* @var string $title */
@@ -45,11 +46,17 @@ $siteName = Website::getWebsiteName();
             rel="stylesheet"/>
 
         <?php
-            View::loadInclude($includes, 'styles');
+        View::loadInclude($includes, 'styles');
         ?>
 
         <?= ImagesManager::getFaviconInclude() ?>
     </head>
+    <style>
+        :root {
+            --header-background: linear-gradient(to bottom, rgba(92, 77, 66, 0.8) 0%, rgba(92, 77, 66, 0.8) 100%),
+            url('<?= ThemeModel::getInstance()->fetchImageLink('background') ?>');
+        }
+    </style>
 <body id="page-top">
 <?php View::loadInclude($includes, 'beforeScript', 'beforePhp'); ?>
 <?= CoreController::getInstance()->cmwWarn() ?>


### PR DESCRIPTION
Add a brand new feature "Components".

Stop HTML and boring DOOOOM.

Now you can create and reuse your components...

Ex:
```php
<?php

namespace CMW\Theme\Sampler\Elements\Inputs;

use CMW\Manager\Components\Base\InputComponentBase;

class PasswordInputComponent extends InputComponentBase
{
    public function render(): void
    {
        InputComponentBase::create()
            ->setClasses("form-control")
            ->setPlaceholder("*****")
            ->setType("password")
            ->render();
    }
}
```

How to use it ?
```php

<?php PasswordInputComponent::create()->render(); ?>
```

Easy, no ?

Kiss
