### PR TITLE
[IMPROVE] Add Slack webhooks

### DIFF
--- a/App/Manager/Webhook/Slack/SlackAttachmentFieldWebhook.php
+++ b/App/Manager/Webhook/Slack/SlackAttachmentFieldWebhook.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Slack Webhook
+ *
+ * This class is inspired by => https://github.com/SimonBackx/Slack-PHP-Webhook
+ */
+
+namespace CMW\Manager\Webhook\Slack;
+
+class SlackAttachmentFieldWebhook
+{
+    // Required
+    public string $title = "";
+    public string $value = "";
+
+    // Optional
+    public ?bool $short;
+
+    public function __construct(string $title, string $value, ?bool $short = NULL)
+    {
+        $this->title = $title;
+        $this->value = $value;
+        if (isset($short)) {
+            $this->short = $short;
+        }
+    }
+
+    public function setShort(bool $bool = true): static
+    {
+        $this->short = $bool;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        $data = [
+            'title' => $this->title,
+            'value' => $this->value,
+        ];
+        if (isset($this->short)) {
+            $data['short'] = $this->short;
+        }
+        return $data;
+    }
+}

--- a/App/Manager/Webhook/Slack/SlackAttachmentWebhook.php
+++ b/App/Manager/Webhook/Slack/SlackAttachmentWebhook.php
@@ -1,0 +1,342 @@
+<?php
+
+/**
+ * Slack Webhook
+ *
+ * This class is inspired by => https://github.com/SimonBackx/Slack-PHP-Webhook
+ */
+
+
+namespace CMW\Manager\Webhook\Slack;
+
+class SlackAttachmentWebhook
+{
+    // Required
+    public string $fallback = "";
+
+    // Optionals
+    public string $color;
+    public string $pretext;
+    public ?string $authorName;
+    public ?string $authorIcon;
+    public string $authorLink;
+    public string $title;
+    public ?string $titleLink;
+    public string $text;
+    public array $fields;
+    public mixed $mrkdwnInFields;
+    public string $imageUrl;
+    public string $thumbUrl;
+
+    // Footer
+    public string $footer;
+    public string $footerIcon;
+    public int $ts;
+
+    // Actions
+    public array $actions;
+
+    public function __construct(string $fallback)
+    {
+        $this->fallback = $fallback;
+    }
+
+    /**
+     * Accepted values: "good", "warning", "danger" or any hex color code
+     */
+    public function setColor(string $color): static
+    {
+        $this->color = $color;
+        return $this;
+    }
+
+    public function setText(string $text): static
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    /**
+     * Optional text that appears above the attachment block
+     */
+    public function setPretext(string $pretext): static
+    {
+        $this->pretext = $pretext;
+        return $this;
+    }
+
+    /**
+     * The author parameters will display a small section at the top of a message attachment.
+     * @param string $authorName [description]
+     * @param string|null $authorLink A valid URL that will hyperlink the author_name text mentioned above. Set to NULL to ignore this value.
+     * @param string|null $authorIcon A valid URL that displays a small 16x16px image to the left of the author_name text. Set to NULL to ignore this value.
+     * @return \CMW\Manager\Webhook\Slack\SlackAttachmentWebhook
+     */
+    public function setAuthor(string $authorName, ?string $authorLink = NULL, ?string $authorIcon = NULL): static
+    {
+        $this->setAuthorName($authorName);
+        if (isset($authorLink)) {
+            $this->setAuthorLink($authorLink);
+        }
+
+        if (isset($authorIcon)) {
+            $this->setAuthorIcon($authorIcon);
+        }
+
+        return $this;
+    }
+
+    public function setAuthorName(?string $authorName): static
+    {
+        $this->authorName = $authorName;
+        return $this;
+    }
+
+    /**
+     * Enable text formatting for: "pretext", "text" or "fields".
+     * Setting "fields" will enable markup formatting for the value of each field.
+     */
+    public function enableMarkdownFor(mixed $mrkdwnInFields): static
+    {
+        if (!isset($this->mrkdwnInFields)) {
+            $this->mrkdwnInFields = [$mrkdwnInFields];
+            return $this;
+        }
+        $this->mrkdwnInFields[] = $mrkdwnInFields;
+        return $this;
+    }
+
+    /**
+     * A valid URL that displays a small 16x16px image to the left of the author_name text.
+     */
+    public function setAuthorIcon($authorIcon): static
+    {
+        $this->authorIcon = $authorIcon;
+        return $this;
+    }
+
+    /**
+     * A valid URL that will hyperlink the author_name text mentioned above.
+     */
+    public function setAuthorLink($authorLink): static
+    {
+        $this->authorLink = $authorLink;
+        return $this;
+    }
+
+    /**
+     * The title is displayed as larger, bold text near the top of a message attachment.
+     * @param string $title
+     * @param string|null $link By passing a valid URL in the link parameter (optional), the
+     * title text will be hyperlinked.
+     * @return \CMW\Manager\Webhook\Slack\SlackAttachmentWebhook
+     */
+    public function setTitle(string $title, ?string $link = NULL): static
+    {
+        $this->title = $title;
+        if (isset($link)) {
+            $this->titleLink = $link;
+        }
+        return $this;
+    }
+
+    /**
+     * A valid URL to an image file that will be displayed inside a message attachment. We currently
+     *  support the following formats: GIF, JPEG, PNG, and BMP.
+     *
+     *  Large images will be resized to a maximum width of 400px or a maximum height of 500px, while
+     *   still maintaining the original aspect ratio.
+     * @param string $url
+     * @return \CMW\Manager\Webhook\Slack\SlackAttachmentWebhook
+     */
+    public function setImage(string $url): static
+    {
+        $this->imageUrl = $url;
+        return $this;
+    }
+
+    /**
+     * A valid URL to an image file that will be displayed as a thumbnail on the right side of a
+     * message attachment. We currently support the following formats: GIF, JPEG, PNG, and BMP.
+     *
+     * The thumbnail's longest dimension will be scaled down to 75px while maintaining the aspect
+     * ratio of the image. The filesize of the image must also be less than 500 KB.
+     *
+     * For best results, please use images that are already 75px by 75px.
+     * @param string $url HTTP url of the thumbnail
+     */
+    public function setThumbnail(string $url): static
+    {
+        $this->thumbUrl = $url;
+        return $this;
+    }
+
+    /**
+     * Add some brief text to help contextualize and identify an attachment. Limited to 300
+     * characters, and may be truncated further when displayed to users in environments with limited
+     *  screen real estate.
+     * @param string $text max 300 characters
+     */
+    public function setFooterText(string $text): static
+    {
+        $this->footer = $text;
+        return $this;
+    }
+
+    /**
+     * To render a small icon beside your footer text, provide a publicly accessible URL string in
+     * the footer_icon field. You must also provide a footer for the field to be recognized.
+     *
+     * We'll render what you provide at 16px by 16px. It's best to use an image that is similarly
+     * sized.
+     * @param string $url 16x16 image url
+     */
+    public function setFooterIcon(string $url): static
+    {
+        $this->footerIcon = $url;
+        return $this;
+    }
+
+    /**
+     * Does your attachment relate to something happening at a specific time?
+     *
+     * By providing the ts field with an integer value in "epoch time", the attachment will display
+     * an additional timestamp value as part of the attachment's footer. Use ts when referencing
+     * articles or happenings. Your message will have its own timestamp when published.
+     *
+     * Example: Providing 123456789 would result in a rendered timestamp of Nov 29th, 1973.
+     * @param int $timestamp Integer value in "epoch time"
+     */
+    public function setTimestamp(int $timestamp): static
+    {
+        $this->ts = $timestamp;
+        return $this;
+    }
+
+    public function addFieldInstance(SlackAttachmentFieldWebhook $field): static
+    {
+        if (!isset($this->fields)) {
+            $this->fields = [$field];
+            return $this;
+        }
+        $this->fields[] = $field;
+        return $this;
+    }
+
+    /**
+     * Shortcut without defining SlackAttachmentField
+     */
+    public function addField(string $title, string $value, ?bool $short = NULL): static
+    {
+        return $this->addFieldInstance(new SlackAttachmentFieldWebhook($title, $value, $short));
+    }
+
+    private function addAction($action): void
+    {
+        if (!isset($this->actions)) {
+            $this->actions = [$action];
+            return;
+        }
+        $this->actions[] = $action;
+    }
+
+    /**
+     * @param string $text A UTF-8 string label for this button. Be brief but descriptive and
+     * actionable.
+     * @param string $url The fully qualified http or https URL to deliver users to. Invalid URLs
+     * will result in a message posted with the button omitted
+     * @param ?string $style (optional) Setting to primary turns the button green and indicates the
+     * best forward action to take. Providing danger turns the button red and indicates it some kind
+     *  of destructive action. Use sparingly. Be default, buttons will use the UI's default text
+     *  color.
+     */
+    public function addButton(string $text, string $url, ?string $style = null): static
+    {
+        $action = (object)[
+            "type" => "button",
+            "text" => $text,
+            "url" => $url,
+        ];
+        if (isset($style)) {
+            $action->style = $style;
+        }
+        $this->addAction($action);
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        $data = [
+            'fallback' => $this->fallback,
+        ];
+        if (isset($this->color)) {
+            $data['color'] = $this->color;
+        }
+
+        if (isset($this->pretext)) {
+            $data['pretext'] = $this->pretext;
+        }
+
+        if (isset($this->authorName)) {
+            $data['author_name'] = $this->authorName;
+        }
+
+        if (isset($this->mrkdwnInFields)) {
+            $data['mrkdwn_in'] = $this->mrkdwnInFields;
+        }
+
+        if (isset($this->authorLink)) {
+            $data['author_link'] = $this->authorLink;
+        }
+
+        if (isset($this->authorIcon)) {
+            $data['author_icon'] = $this->authorIcon;
+        }
+
+        if (isset($this->title)) {
+            $data['title'] = $this->title;
+        }
+
+        if (isset($this->titleLink)) {
+            $data['title_link'] = $this->titleLink;
+        }
+
+        if (isset($this->text)) {
+            $data['text'] = $this->text;
+        }
+
+        if (isset($this->fields)) {
+            $fields = [];
+            foreach ($this->fields as $field) {
+                $fields[] = $field->toArray();
+            }
+            $data['fields'] = $fields;
+        }
+
+        if (isset($this->imageUrl)) {
+            $data['image_url'] = $this->imageUrl;
+        }
+
+        if (isset($this->thumbUrl)) {
+            $data['thumb_url'] = $this->thumbUrl;
+        }
+
+        if (isset($this->footer)) {
+            $data['footer'] = $this->footer;
+        }
+
+        if (isset($this->footerIcon)) {
+            $data['footer_icon'] = $this->footerIcon;
+        }
+
+        if (isset($this->ts)) {
+            $data['ts'] = $this->ts;
+        }
+
+        if (isset($this->actions)) {
+            $data['actions'] = (array)$this->actions;
+        }
+
+        return $data;
+    }
+}

--- a/App/Manager/Webhook/Slack/SlackMessageWebhook.php
+++ b/App/Manager/Webhook/Slack/SlackMessageWebhook.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Slack Webhook
+ *
+ * This class is inspired by => https://github.com/SimonBackx/Slack-PHP-Webhook
+ */
+
+
+namespace CMW\Manager\Webhook\Slack;
+
+class SlackMessageWebhook
+{
+    private SlackWebhook $slack;
+
+    // Message to post
+    public string $text = "";
+
+    // Empty => Default username set in Slack instance
+    public string $username;
+
+    // Empty => Default channel set in Slack instance
+    public string $channel;
+
+    // Empty => Default icon set in Slack instance
+    public string $iconUrl;
+
+    // Empty => Default icon set in Slack instance
+    public string $iconEmoji;
+
+    public false|string $unfurlLinks;
+
+    // Array of SlackAttachment instances
+    /*  */
+    public array $attachments;
+
+    public function __construct(SlackWebhook $slack)
+    {
+        $this->slack = $slack;
+    }
+
+    /*
+    Settings
+     */
+    public function setText($text): static
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    public function setUsername($username): static
+    {
+        $this->username = $username;
+        return $this;
+    }
+
+    public function setChannel($channel): static
+    {
+        $this->channel = $channel;
+        return $this;
+    }
+
+    public function setEmoji($emoji): static
+    {
+        $this->iconEmoji = $emoji;
+        return $this;
+    }
+
+    public function setIcon($url): static
+    {
+        $this->iconUrl = $url;
+        return $this;
+    }
+
+    public function setUnfurlLinks($bool): static
+    {
+        $this->unfurlLinks = $bool;
+        return $this;
+    }
+
+    public function addAttachment(SlackAttachment $attachment): static
+    {
+        if (!isset($this->attachments)) {
+            $this->attachments = [$attachment];
+            return $this;
+        }
+
+        $this->attachments[] = $attachment;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        // Loading defaults
+        if (isset($this->slack->username)) {
+            $username = $this->slack->username;
+        }
+
+        if (isset($this->slack->channel)) {
+            $channel = $this->slack->channel;
+        }
+
+        if (isset($this->slack->icon_url)) {
+            $icon_url = $this->slack->icon_url;
+        }
+
+        if (isset($this->slack->icon_emoji)) {
+            $icon_emoji = $this->slack->icon_emoji;
+        }
+
+        if (isset($this->slack->unfurl_links)) {
+            $unfurl_links = $this->slack->unfurl_links;
+        }
+
+        // Overwrite/create defaults
+        if (isset($this->username)) {
+            $username = $this->username;
+        }
+
+        if (isset($this->channel)) {
+            $channel = $this->channel;
+        }
+
+        if (isset($this->iconUrl)) {
+            $icon_url = $this->iconUrl;
+        }
+
+        if (isset($this->iconEmoji)) {
+            $icon_emoji = $this->iconEmoji;
+        }
+
+        if (isset($this->unfurlLinks)) {
+            $unfurl_links = $this->unfurlLinks;
+        }
+
+        $data = [
+            'text' => $this->text,
+        ];
+        if (isset($username)) {
+            $data['username'] = $username;
+        }
+
+        if (isset($channel)) {
+            $data['channel'] = $channel;
+        }
+
+        if (isset($icon_url)) {
+            $data['icon_url'] = $icon_url;
+        } else if (isset($icon_emoji)) {
+            $data['icon_emoji'] = $icon_emoji;
+        }
+
+        if (isset($unfurl_links)) {
+            $data['unfurl_links'] = $unfurl_links;
+        }
+
+        if (isset($this->attachments)) {
+            $attachments = [];
+            foreach ($this->attachments as $attachment) {
+                $attachments[] = $attachment->toArray();
+            }
+            $data['attachments'] = $attachments;
+        }
+        return $data;
+    }
+
+    /*
+     * Send this message to Slack
+     */
+    public function send(): bool
+    {
+        return $this->slack->send($this);
+    }
+}

--- a/App/Manager/Webhook/Slack/SlackWebhook.php
+++ b/App/Manager/Webhook/Slack/SlackWebhook.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Slack Webhook
+ *
+ * This class is inspired by => https://github.com/SimonBackx/Slack-PHP-Webhook
+ */
+
+namespace CMW\Manager\Webhook\Slack;
+
+use Exception;
+
+class SlackWebhook
+{
+    // WebhookUrl e.g. https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
+    public string $url;
+
+    // Empty => Default username set in Slack Webhook integration settings
+    public string $username;
+
+    // Empty => Default channel set in Slack Webhook integration settings
+    public string $channel;
+
+    // Empty => Default icon set in Slack Webhook integration settings
+    public string $iconUrl;
+
+    // Empty => Default icon set in Slack Webhook integration settings
+    public string $icon_emoji;
+
+    // Unfurl links: automatically fetch and create attachments for URLs
+    // Empty = default (false)
+    public false|string $unfurlLinks = false;
+
+    public function __construct($webhookUrl)
+    {
+        $this->url = $webhookUrl;
+    }
+
+    function __isset($property)
+    {
+        return isset($this->$property);
+    }
+
+    public function send(SlackMessageWebhook $message): bool
+    {
+        $data = $message->toArray();
+
+        try {
+            $json = json_encode($data);
+
+            $curl = curl_init();
+            curl_setopt_array($curl, [
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_URL => $this->url,
+                CURLOPT_USERAGENT => 'cURL Request',
+                CURLOPT_POST => 1,
+                CURLOPT_POSTFIELDS => ['payload' => $json],
+            ]);
+            $result = curl_exec($curl);
+
+            if (!$result) {
+                return false;
+            }
+
+            curl_close($curl);
+
+            return $result === 'ok';
+        } catch (Exception $e) {
+            return false;
+        }
+
+    }
+
+    public function setDefaultUnfurlLinks($unfurl): static
+    {
+        $this->unfurlLinks = $unfurl;
+        return $this;
+    }
+
+    public function setDefaultChannel($channel): static
+    {
+        $this->channel = $channel;
+        return $this;
+    }
+
+    public function setDefaultUsername($username): static
+    {
+        $this->username = $username;
+        return $this;
+    }
+
+    public function setDefaultIcon($url): static
+    {
+        $this->iconUrl = $url;
+        return $this;
+    }
+
+    public function setDefaultEmoji($emoji): static
+    {
+        $this->icon_emoji = $emoji;
+        return $this;
+    }
+}


### PR DESCRIPTION
How to use:

Simple Message integration:
```php
        $slack = new SlackWebhook("https://hooks.slack.com/services/YOUR_URL");
        $message = new SlackMessageWebhook($slack);
        $message->setText("Hello CMW !!!");

        $message->send();
```

More informations here => https://github.com/SimonBackx/Slack-PHP-Webhook