### PR TITLE
[GEN-32] Users settings bulk + singleton

### DIFF
--- a/App/Package/Users/Controllers/UsersController.php
+++ b/App/Package/Users/Controllers/UsersController.php
@@ -369,13 +369,13 @@ class UsersController extends AbstractController
                 Redirect::redirectPreviousRoute();
             }
             // We send a verification link for this mail
-            if (UsersSettingsModel::getSetting('resetPasswordMethod') === '0') {
+            if (UsersSettingsModel::getInstance()->getSetting('resetPasswordMethod') === '0') {
                 $this->resetPasswordMethodPasswordSendByMail($encryptedMail);
 
                 Flash::send(Alert::SUCCESS, LangManager::translate('core.toaster.success'),
                     LangManager::translate('users.toaster.password_reset', ['mail' => $mail]));
 
-            } elseif (UsersSettingsModel::getSetting('resetPasswordMethod') === '1') {
+            } elseif (UsersSettingsModel::getInstance()->getSetting('resetPasswordMethod') === '1') {
                 $this->resetPasswordMethodUniqueLinkSendByMail($encryptedMail);
 
                 Flash::send(Alert::SUCCESS, LangManager::translate('core.toaster.success'), LangManager::translate('users.toaster.reset_link_follow_the_link'));

--- a/App/Package/Users/Controllers/UsersLoginController.php
+++ b/App/Package/Users/Controllers/UsersLoginController.php
@@ -71,7 +71,7 @@ class UsersLoginController extends AbstractController
 
         $userLastConnect = $user->getLastConnectionUnformatted();
 
-        if ((UsersSettingsModel::getSetting('securityReinforced') === '1') && $this->isUserInactiveFor90Days($userLastConnect) && !$user->get2Fa()->isEnabled() && MailModel::getInstance()->getConfig() !== null && MailModel::getInstance()->getConfig()->isEnable()) {
+        if ((UsersSettingsModel::getInstance()->getSetting('securityReinforced') === '1') && $this->isUserInactiveFor90Days($userLastConnect) && !$user->get2Fa()->isEnabled() && MailModel::getInstance()->getConfig() !== null && MailModel::getInstance()->getConfig()->isEnable()) {
             return LoginStatus::OK_LONG_DATE;
         }
 

--- a/App/Package/Users/Entities/Settings/BulkSettingsEntity.php
+++ b/App/Package/Users/Entities/Settings/BulkSettingsEntity.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CMW\Entity\Users\Settings;
+
+use CMW\Manager\Package\AbstractEntity;
+
+/**
+ * Class: @BulkSettingsEntity
+ * @package Users
+ * @link https://craftmywebsite.fr/docs/fr/technical/creer-un-package/entities
+ */
+class BulkSettingsEntity extends AbstractEntity
+{
+    private string $name;
+    private string $value;
+
+    public function __construct(string $name, string $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/App/Package/Users/Entities/UserSettingsEntity.php
+++ b/App/Package/Users/Entities/UserSettingsEntity.php
@@ -16,9 +16,9 @@ class UserSettingsEntity extends AbstractEntity
 
     public function __construct()
     {
-        $this->defaultImage = UsersSettingsModel::getSetting('defaultImage');
-        $this->profilePageStatus = (int)UsersSettingsModel::getSetting('profilePage');
-        $this->resetPasswordMethod = (int)UsersSettingsModel::getSetting('resetPasswordMethod');
+        $this->defaultImage = UsersSettingsModel::getInstance()->getSetting('defaultImage');
+        $this->profilePageStatus = (int)UsersSettingsModel::getInstance()->getSetting('profilePage');
+        $this->resetPasswordMethod = (int)UsersSettingsModel::getInstance()->getSetting('resetPasswordMethod');
     }
 
     public static function getInstance(): self

--- a/App/Package/Users/Models/UserPictureModel.php
+++ b/App/Package/Users/Models/UserPictureModel.php
@@ -57,7 +57,7 @@ class UserPictureModel extends AbstractModel
 
     public function userHasDefaultImage(int $userId): bool
     {
-        return is_file(EnvManager::getInstance()->getValue('DIR') . 'Public/Uploads/Users/Default/' . UsersSettingsModel::getSetting('defaultImage')) && !$this->userHasImage($userId);
+        return is_file(EnvManager::getInstance()->getValue('DIR') . 'Public/Uploads/Users/Default/' . UsersSettingsModel::getInstance()->getSetting('defaultImage')) && !$this->userHasImage($userId);
     }
 
     /**

--- a/App/Package/Users/Views/settings.admin.view.php
+++ b/App/Package/Users/Views/settings.admin.view.php
@@ -67,10 +67,10 @@ $description = LangManager::translate('users.settings.desc');
             <div>
                 <label for="security_reinforced"><?= LangManager::translate('users.long_date.setting.label') ?></label>
                 <select class="form-select" id="security_reinforced" name="security_reinforced" required>
-                    <option value="0" <?= UsersSettingsModel::getSetting('securityReinforced') === '0' ? 'selected' : '' ?>>
+                    <option value="0" <?= UsersSettingsModel::getInstance()->getSetting('securityReinforced') === '0' ? 'selected' : '' ?>>
                         <?= LangManager::translate('users.long_date.setting.no') ?>
                     </option>
-                    <option value="1" <?= UsersSettingsModel::getSetting('securityReinforced') === '1' ? 'selected' : '' ?>>
+                    <option value="1" <?= UsersSettingsModel::getInstance()->getSetting('securityReinforced') === '1' ? 'selected' : '' ?>>
                         <?= LangManager::translate('users.long_date.setting.yes') ?>
                     </option>
                 </select>
@@ -81,8 +81,8 @@ $description = LangManager::translate('users.settings.desc');
                 <label>Double facteur obligatoire</label>
                 <fieldset class="form-group">
                     <select class="form-select" id="listEnforcedToggle" name="listEnforcedToggle" required>
-                        <option value="0" <?php if (!UsersSettingsModel::getSetting('listEnforcedToggle')) { echo 'selected'; } ?>>Pas d'obligation</option>
-                        <option value="1" <?php if (UsersSettingsModel::getSetting('listEnforcedToggle')) { echo 'selected'; } ?>>Ayant le rôle :</option>
+                        <option value="0" <?php if (!UsersSettingsModel::getInstance()->getSetting('listEnforcedToggle')) { echo 'selected'; } ?>>Pas d'obligation</option>
+                        <option value="1" <?php if (UsersSettingsModel::getInstance()->getSetting('listEnforcedToggle')) { echo 'selected'; } ?>>Ayant le rôle :</option>
                     </select>
                 </fieldset>
                 <div class="mt-2" id="listEnforcedRoles">


### PR DESCRIPTION
How to use:

## bulkAddSettings
```php
UsersSettingsModel::getInstance()->bulkAddSettings(
            new BulkSettingsEntity('test1', 'value1'),
            new BulkSettingsEntity('test2', 'value2'),
            new BulkSettingsEntity('test3', 'value3')
        );
```

## bulkUpdateSettings
```php
UsersSettingsModel::getInstance()->bulkUpdateSettings(
            new BulkSettingsEntity('test1', 'value1'),
            new BulkSettingsEntity('test2', 'value2'),
            new BulkSettingsEntity('test3', 'value3')
        );
```
For **bulkUpdateSettings** if an update failed, all the statement is rollback and we throw an error.